### PR TITLE
Change example of pathing in Webpack to use path.resolve

### DIFF
--- a/integration-tests/example-site/forge.config.js
+++ b/integration-tests/example-site/forge.config.js
@@ -9,6 +9,6 @@ module.exports = {
     assets: './src/assets',
     layouts: './src/layouts',
     build: './build',
-    scripts: './scripts'
+    scripts: './src/scripts'
   }
 }

--- a/integration-tests/example-site/webpack.config.js
+++ b/integration-tests/example-site/webpack.config.js
@@ -7,7 +7,7 @@ const ASSET_PATH = process.env.ASSET_PATH || '/';
 
 let config = {
   entry: {
-    main: './src/scripts/main.js'
+    main: path.resolve(forgeConfig.dirs.scripts, 'main.js')
   },
   output: {
     publicPath: ASSET_PATH,

--- a/lib/initer.js
+++ b/lib/initer.js
@@ -5,7 +5,7 @@ const jetpack = require('fs-jetpack')
 
 module.exports = function () {
   // create directories
-  ['assets', 'includes', 'layouts', 'src'].map(d => { jetpack.dir(d) })
+  ['src/assets', 'src/layouts', 'src/pages'].map(d => { jetpack.dir(d) })
 
   // write default forge config file
   jetpack.write('forge.config.js',
@@ -16,9 +16,9 @@ module.exports = function () {
     }
   },
   dirs: {
-    source: './src',
-    assets: './assets',
-    layouts: './layouts',
+    pages: './src/pages',
+    assets: './src/assets',
+    layouts: './src/layouts',
     build: './build'
   }
 }`)

--- a/lib/reusable/toolbox.js
+++ b/lib/reusable/toolbox.js
@@ -6,6 +6,7 @@ import { Left, Right } from 'crocks/Either'
 // ForgeConfig -> String -> Either(Error String, String)
 // Ensures the given path is safe to use for output - meaning it's in the build
 // directory and won't cause overwrites or deletes of client project files.
+// TODO: this doesn't below in reusable/toolbox!
 export const outPathIsSafe = (config, thePath) => {
   if (!config) {
     return Left(new Error(`Given config is empty`))
@@ -31,6 +32,7 @@ export const outPathIsSafe = (config, thePath) => {
 }
 
 // ForgeConfig -> String -> Async(Error String, String)
+// TODO: this doesn't below in reusable/toolbox!
 export const deletePathIfSafe = (config, thePath) =>
   eitherToAsync(
     outPathIsSafe(config, thePath)


### PR DESCRIPTION
path.join doesn't work since forge config paths are stripped of leading ./

path.resolve will create an absolute path and assume ./ if the path has no beginning quantifiers