### PR TITLE
Support production builds that are not at the domain root

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,14 @@ Expects a file named `forge.config.js` to be in the project directory:
 ```javascript
 module.exports = {
   metadata: {
+    baseurl: '',
     ...
   },
+
   forgeVersion: "4.0.0",
+
   dirs: {
     pages: './src/pages',
-    assets: './src/assets',
     layouts: './src/layouts',
     build: './build',
     scripts: './src/scripts'
@@ -69,9 +71,13 @@ module.exports = {
 }
 ```
 
-### Metadata
+### metadata
 
 This object is merged with the front matter of every page when the page is rendered. It's actually a 3-way merge between the page's front matter (overrides everything), the front matter inherited from the page's layout (takes 2nd priority) and the metadata (takes last priority).
+
+#### baseurl
+
+Optional, prefix to append to beginning of all URLs in production build in case the generated site is not directly under a domain. For example, if you upload the site to `somedomain.com/my-special-site` then `baseurl` should be `/my-special-site`
 
 ### forgeVersion
 

--- a/configs/webpack.config.js
+++ b/configs/webpack.config.js
@@ -77,6 +77,30 @@ const makeConfig = mode => {
             { loader: 'css-loader', options: { importLoaders: 1 } },
             { loader: 'postcss-loader', options: { config: { path: path.resolve(__dirname, '../configs') } } }
           ]
+        },
+        // load any image assets into assets/images
+        {
+          test: /\.(png|jpe?g|gif|svg)(\?.*)?$/,
+          use: {
+            loader: 'url-loader',
+            query: {
+              limit: 10000,
+              // relative to the output directory
+              name: 'assets/images/[name].[ext]'
+            }
+          }
+        },
+        // load any image assets into assets/fonts
+        {
+          test: /\.(woff2?|eot|ttf|otf)(\?.*)?$/,
+          use: {
+            loader: 'url-loader',
+            query: {
+              limit: 10000,
+              // relative to the output directory
+              name: 'assets/fonts/[name].[ext]'
+            }
+          }
         }
       ]
     },

--- a/index.js
+++ b/index.js
@@ -79,6 +79,9 @@ if (mode === 'build') {
     }
   )
 } else if (mode === 'prototype') {
+  // no prefix in prototype mode
+  config.metadata.baseurl = ''
+
   builder.prototype(config)
   .fork(
     // failed

--- a/lib/builder/build.js
+++ b/lib/builder/build.js
@@ -1,10 +1,6 @@
 // code for HTML building - build mode
 
-import path from 'path'
-
-import jetpack from 'fs-jetpack'
 import Async from 'crocks/Async'
-import { Rejected, Resolved } from 'crocks/Async'
 import eitherToAsync from 'crocks/Async/eitherToAsync'
 import { identity } from 'crocks/combinators'
 
@@ -12,18 +8,15 @@ import { logInfo, logDetail } from '../logging'
 import { loadLayouts } from './layouts'
 import { loadPages, createPageRenderers, writePages } from './pages'
 import { objectToArray } from '../reusable/functional'
-import { outPathIsSafe, deletePathIfSafe } from '../reusable/toolbox'
+import { deletePathIfSafe } from '../reusable/toolbox'
 
 // ForgeConfig -> { Layout}(optional) -> [ Page ](optional) -> Async(Error String, ())
 // run a production build
 // builds HTML and copies assets
 export const build = (config, layouts, pages) => {
-  let createRenderers = copyAssets(config)
-  .chain(() =>
-    Async.of(createPageRenderers(config))
-    .ap(eitherToAsync(layouts || loadLayouts(config)))
-    .ap(eitherToAsync(pages || loadPages(config)))
-  )
+  let createRenderers = Async.of(createPageRenderers(config))
+  .ap(eitherToAsync(layouts || loadLayouts(config)))
+  .ap(eitherToAsync(pages || loadPages(config)))
   // We've wrapped `createPageRenderers` in an Async so we can conveniently load
   // the layouts and pages concurrently and apply them to it. However, that
   // function ultimately returns an Async. So we've got nested Asyncs. To
@@ -64,28 +57,3 @@ export const cleanBuild = config => {
   logInfo('Cleaning build')
   return deletePathIfSafe(config, config.dirs.build)
 }
-
-// ForgeConfig -> Async(Error String, String)
-const copyAssets = config =>
-  eitherToAsync(
-    outPathIsSafe(
-      config,
-      path.join(
-        config.dirs.build,
-        path.basename(config.dirs.assets)
-      )
-    )
-  )
-  .chain(p => {
-    try {
-      jetpack.copy(
-        config.dirs.assets,
-        p,
-        { overwrite: true }
-      )
-    } catch (exc) {
-      return Rejected(exc)
-    }
-
-    return Resolved(p)
-  })

--- a/lib/builder/prototype.js
+++ b/lib/builder/prototype.js
@@ -2,7 +2,6 @@
 
 import path from 'path'
 
-import jetpack from 'fs-jetpack'
 import chokidar from 'chokidar'
 import Async from 'crocks/Async'
 import { Resolved, Rejected } from 'crocks/Async'
@@ -16,7 +15,7 @@ import { loadLayouts, loadLayout } from './layouts'
 import { loadPages, loadPage, addPage, removePage, renderAndWritePage } from './pages'
 import { sourcePagePathToBuildPagePath, applyLayout } from './common'
 import { saySome, noop } from '../reusable/functional'
-import { deletePathIfSafe, outPathIsSafe } from '../reusable/toolbox'
+import { deletePathIfSafe } from '../reusable/toolbox'
 
 // ForgeConfig -> Async
 // start a prototyping, watching build
@@ -75,24 +74,6 @@ const startWatching = config => {
     layoutWatcher.on('add', layoutFileAdded(config, context))
     layoutWatcher.on('change', layoutFileChanged(config, context))
     layoutWatcher.on('unlink', layoutFileRemoved(config, context))
-  })
-
-  // Now watch the assets
-  let assetWatcher = chokidar.watch(config.dirs.assets, {ignored: /(^|[/\\])\../})
-  assetWatcher.on('ready', () => {
-    assetWatcher.on('add', copyAsset(config, p => logRawDetail('+', p)))
-    assetWatcher.on('change', copyAsset(config, p => logDetail(p)))
-    assetWatcher.on('unlink', filePath => {
-      let { outPath, wOBuild } = assetSrcPathToBuildPath(config, filePath)
-
-      deletePathIfSafe(config, outPath)
-      .fork(
-        logFailure,
-        () => {
-          logRawDetail('-', wOBuild)
-        }
-      )
-    })
   })
 }
 
@@ -253,38 +234,5 @@ const layoutFileRemoved = curry((config, context, filePath) => {
       // remove from the layouts
       context.layouts = removePage(context.layouts, layoutName)
     }
-  )
-})
-
-const assetSrcPathToBuildPath = (config, filePath) => {
-  // file name with possible path
-  const outPath = path.join(
-    // get asset dir name
-    path.basename(config.dirs.assets),
-    // get file name and path relative to src assets directory
-    path.relative(config.dirs.assets, filePath)
-  )
-
-  return {
-    outPath: path.join(config.dirs.build, outPath),
-    wOBuild: outPath
-  }
-}
-
-// ForgeConfig -> (String -> ()) -> String -> ()
-const copyAsset = curry((config, logFunc, filePath) => {
-  let { outPath, wOBuild } = assetSrcPathToBuildPath(config, filePath)
-
-  eitherToAsync(outPathIsSafe(config, outPath))
-  .map(p => {
-    jetpack.copy(
-      filePath,
-      p,
-      { overwrite: true }
-    )
-  })
-  .fork(
-    logFailure,
-    () => logFunc(wOBuild)
   )
 })

--- a/lib/config.js
+++ b/lib/config.js
@@ -12,8 +12,13 @@ export const load = () => {
   let config = unbundledRequire(path.resolve('./forge.config.js'))
 
   // TODO: validate `config` fully
-  if (config.code !== undefined && config.code.entry == undefined) {
-    config.code.entry = './index.js'
+
+  if (config.metadata === undefined) {
+    config.metadata = { }
+  }
+
+  if (config.metadata.baseurl === undefined) {
+    config.metadata.baseurl = ''
   }
 
   if (!config.dirs) {
@@ -24,12 +29,6 @@ export const load = () => {
 
   if (!config.dirs.build) {
     logFailure('Config has no \'dirs.build\' section')
-    // TODO: don't kill process
-    process.exit(1)
-  }
-
-  if (!config.dirs.assets) {
-    logFailure('Config has no \'dirs.assets\' section')
     // TODO: don't kill process
     process.exit(1)
   }

--- a/lib/initer.js
+++ b/lib/initer.js
@@ -3,6 +3,8 @@
 const path = require('path')
 const jetpack = require('fs-jetpack')
 
+const forgePackage = require('../package.json')
+
 module.exports = function () {
   // create directories
   ['src/assets', 'src/layouts', 'src/pages'].map(d => { jetpack.dir(d) })
@@ -11,13 +13,16 @@ module.exports = function () {
   jetpack.write('forge.config.js',
 `module.exports = {
   metadata: {
+    baseurl: '',
     site: {
       title: 'A New Forge Project'
     }
   },
+
+  forgVersion: '${forgePackage.version}',
+
   dirs: {
     pages: './src/pages',
-    assets: './src/assets',
     layouts: './src/layouts',
     build: './build'
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "forge",
-  "version": "0.1.0",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3687,6 +3687,27 @@
       "requires": {
         "flat-cache": "^1.2.1",
         "object-assign": "^4.0.1"
+      }
+    },
+    "file-loader": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-3.0.1.tgz",
+      "integrity": "sha512-4sNIOXgtH/9WZq4NvlfU3Opn5ynUsqBwSLyM+I7UOwdGigTBYfVVQEwe/msZNX/j4pCJTIM14Fsw66Svo1oVrw==",
+      "requires": {
+        "loader-utils": "^1.0.2",
+        "schema-utils": "^1.0.0"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
       }
     },
     "filename-regex": {
@@ -10966,6 +10987,33 @@
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
+      }
+    },
+    "url-loader": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-1.1.2.tgz",
+      "integrity": "sha512-dXHkKmw8FhPqu8asTc1puBfe3TehOCo2+RmOOev5suNCIYBcT626kxiWg1NBVkwc4rO8BGa7gP70W7VXuqHrjg==",
+      "requires": {
+        "loader-utils": "^1.1.0",
+        "mime": "^2.0.3",
+        "schema-utils": "^1.0.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.2.tgz",
+          "integrity": "sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg=="
+        },
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Pre-configured stack to build static websites.",
   "repository": {
     "type": "git",
@@ -30,6 +30,7 @@
     "eslint-formatter-friendly": "^6.0.0",
     "eslint-loader": "^2.1.2",
     "eslint-plugin-vue": "^5.1.0",
+    "file-loader": "^3.0.1",
     "fs-jetpack": "^2.2.0",
     "glob-all": "^3.1.0",
     "highlight.js": "^9.13.1",
@@ -55,6 +56,7 @@
     "ssh2-sftp-client": "^3.1.0",
     "style-loader": "^0.23.1",
     "tailwindcss": "^0.6.5",
+    "url-loader": "^1.1.2",
     "vue": "^2.5.22",
     "vue-devtools": "^5.0.0-beta.1",
     "vue-eslint-parser": "^5.0.0",


### PR DESCRIPTION
Introduced a "baseurl" concept to prefix all URLs in case the generated site is not at the domain root.

Also moved all asset management to Webpack so it can handle the paths. Removed asset management from forge.

Closes #31